### PR TITLE
Fix wrongly used const in the short-circuiting section.

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -474,7 +474,7 @@ const object = {
 
             <h4 class="not-recommended">Not Recommended:</h4>
             <pre><code class="not-recommended">const foo = (name) => {
-    const theName;
+    let theName;
     if (name) {
         theName = name;
     } else {


### PR DESCRIPTION
An update was done to the scripts and all `var` become `const`. But in one section that creates some wrong code because the variable is subsequently assigned a value based on an `if` statement.

So this update uses `let` for that one example.