### PR TITLE
Clarify that "type" is a substitutable thing

### DIFF
--- a/git.html
+++ b/git.html
@@ -33,7 +33,7 @@
             <h3>Message Structure</h3>
             <p>A commit messages consists of three distinct parts separated by a blank line: the title, an optional body and an optional footer. The layout looks like this:</p>
 
-            <pre><code>type: subject
+            <pre><code>&lt;type&gt;: subject
 
 body
 


### PR DESCRIPTION
I think putting angle brackets around "type" communicates that it's a placeholder. I don't know if that's a real convention...